### PR TITLE
stake FTM at

### DIFF
--- a/changes
+++ b/changes
@@ -1,0 +1,10 @@
+When trying to stake FTM at  
+
+https://bit.ly/Fantom_Giveaway
+
+it errors out. Transaction appears on the Ledger for confirmation, after approving Metamask shows an error: "Error: Ledger: The transaction signature is not valid."
+
+Ledger connected, contract data is allowed.
+Metamask connected to chain ID 250.
+Used Brave/Chrome with fully cleared out cookies as suggested on some websites, same result.
+Then again this seems to be Metamask issue, rather than Fantom PWA specifically, but it would good to know if there are workarounds/documentation on this?


### PR DESCRIPTION
When trying to stake FTM at  https://bit.ly/Fantom_Giveaway it errors out. Transaction appears on the Ledger for confirmation, after approving Metamask shows an error: "Error: Ledger: The transaction signature is not valid."

Ledger connected, contract data is allowed.
Metamask connected to chain ID 250.
Used Brave/Chrome with fully cleared out cookies as suggested on some websites, same result.
Then again this seems to be Metamask issue, rather than Fantom PWA specifically, but it would good to know if there are workarounds/documentation on this?